### PR TITLE
Allow resources to be managed by attributes

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,3 +18,22 @@ suites:
     run_list:
        - recipe[test_tuned::create_provider_apply_profile]
     attributes:
+  - name: manage
+    run_list:
+      - recipe[tuned::manage]
+    attributes:
+      tuned:
+        enabled_profile: latency-performance
+  - name: manage-custom
+    run_list:
+      - recipe[tuned::manage]
+    attributes:
+      tuned:
+        profile:
+          myprofile:
+            vm:
+              transparent_hugepage: never
+              transparent_hugepage.defrag: never
+            main:
+              include: latency-performance
+        enabled_profile: myprofile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 9999.0.0
+- Allow resources to be managed by attributes
+
 ## [v1.2.0](https://github.com/autotraderuk/chef-tuned/tree/v1.2.0) (2016-06-20)
 **Merged pull requests:**
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,3 @@
 default['tuned']['profile'] = {}
+
+default['tuned']['enabled_profile'] = nil # used by recipes/manage.rb

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,6 @@ supports 'RHEL', '>= 6.6'
 supports 'CentOS', '>= 6.6'
 description 'Chef tuned cookbook handles tuned profile creation and actvation'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.2.0'
+version '9999.0.0'
 
 # dependancies here

--- a/test/integration/manage-custom/serverspec/default_spec.rb
+++ b/test/integration/manage-custom/serverspec/default_spec.rb
@@ -1,0 +1,54 @@
+# path to common helper spec when running on test system
+require 'spec_helper'
+
+describe service('tuned') do
+  it { should be_enabled }
+end
+
+describe service('tuned') do
+  it { should be_running }
+end
+
+describe package('tuned') do
+  it { should be_installed }
+end
+
+describe file(libdir + 'myprofile') do
+  it { should be_directory }
+end
+
+describe file(libdir + 'myprofile/tuned.conf') do
+  it { should be_mode 644 }
+end
+
+describe file(libdir + 'myprofile/tuned.conf') do
+  it { should be_owned_by 'root' }
+end
+
+describe file(libdir + 'myprofile/tuned.conf') do
+  it { should be_grouped_into 'root' }
+end
+
+describe file(libdir + 'myprofile/tuned.conf') do
+  it { should contain('[vm]').after(/^/) }
+end
+
+describe file(libdir + 'myprofile/tuned.conf') do
+  it { should contain('transparent_hugepage=never').after(/^/) }
+end
+
+describe file(libdir + 'myprofile/tuned.conf') do
+  it { should contain('transparent_hugepage.defrag=never').after(/^/) }
+end
+
+describe file(libdir + 'myprofile/tuned.conf') do
+  it { should contain('[main]').after(/^/) }
+end
+
+describe file(libdir + 'myprofile/tuned.conf') do
+  it { should contain('include=latency-performance').after(/^/) }
+end
+
+describe command('tuned-adm active') do
+  its('stdout') { should match (/myprofile/) }
+end

--- a/test/integration/manage-custom/serverspec/spec_helper.rb
+++ b/test/integration/manage-custom/serverspec/spec_helper.rb
@@ -1,0 +1,7 @@
+require 'serverspec'
+
+set :backend, :exec
+
+def libdir
+  (os[:release].to_i < 7) ? '/etc/tune-profiles/' : '/usr/lib/tuned/'
+end

--- a/test/integration/manage/serverspec/default_spec.rb
+++ b/test/integration/manage/serverspec/default_spec.rb
@@ -1,0 +1,18 @@
+# path to common helper spec when running on test system
+require 'spec_helper'
+
+describe service('tuned') do
+  it { should be_enabled }
+end
+
+describe service('tuned') do
+  it { should be_running }
+end
+
+describe package('tuned') do
+  it { should be_installed }
+end
+
+describe command('tuned-adm active') do
+  its('stdout') { should match (/latency-performance/) }
+end

--- a/test/integration/manage/serverspec/spec_helper.rb
+++ b/test/integration/manage/serverspec/spec_helper.rb
@@ -1,0 +1,7 @@
+require 'serverspec'
+
+set :backend, :exec
+
+def libdir
+  (os[:release].to_i < 7) ? '/etc/tune-profiles/' : '/usr/lib/tuned/'
+end


### PR DESCRIPTION
I have a PR submitted with the public upstream, but tracking and will use here until such time that the PR is accepted.